### PR TITLE
fix: typo in writeTo function in env package

### DIFF
--- a/cmd/user-server/internal/env/variables.go
+++ b/cmd/user-server/internal/env/variables.go
@@ -52,7 +52,7 @@ func readTO() time.Duration {
 }
 
 func writeTO() time.Duration {
-	wto := os.Getenv(httpReadTO)
+	wto := os.Getenv(httpWriteTO)
 	if len(wto) == 0 {
 		wto = "10"
 	}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking changes
- [x] Tested

### What did this pull request do?
Fixed typo.
httpReadTO -> httpWriteTO